### PR TITLE
style: adopt dark theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,26 +8,30 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="home.css">
 </head>
-<body class="bg-gray-100 text-gray-800">
-  <header class="bg-white shadow">
+<body class="bg-gray-900 text-gray-100">
+  <header class="bg-gray-800 shadow">
     <nav class="container mx-auto flex items-center justify-between p-4">
       <a href="#home" class="text-xl font-bold">Miguel Reyes</a>
       <ul class="flex space-x-4">
-        <li><a href="#home" class="hover:text-blue-600">Home</a></li>
-        <li><a href="#sobre-mi" class="hover:text-blue-600">Sobre mí</a></li>
-        <li><a href="#formacion" class="hover:text-blue-600">Formación</a></li>
-        <li><a href="#experiencia" class="hover:text-blue-600">Experiencia</a></li>
-        <li><a href="#competencias" class="hover:text-blue-600">Competencias</a></li>
-        <li><a href="#contacto" class="hover:text-blue-600">Contacto</a></li>
-        <li><a href="#proyectos" class="hover:text-blue-600">Proyectos</a></li>
+        <li><a href="#home" class="hover:text-gray-300">Home</a></li>
+        <li><a href="#sobre-mi" class="hover:text-gray-300">Sobre mí</a></li>
+        <li><a href="#formacion" class="hover:text-gray-300">Formación</a></li>
+        <li><a href="#experiencia" class="hover:text-gray-300">Experiencia</a></li>
+        <li><a href="#competencias" class="hover:text-gray-300">Competencias</a></li>
+        <li><a href="#contacto" class="hover:text-gray-300">Contacto</a></li>
+        <li><a href="#proyectos" class="hover:text-gray-300">Proyectos</a></li>
       </ul>
     </nav>
   </header>
   <main class="container mx-auto p-4 space-y-24">
-    <section id="home" class="text-center py-24">
-      <h1 class="text-4xl font-bold mb-4">Miguel Reyes</h1>
-      <p class="text-xl text-gray-600 mb-6">ASIR Student | Tech Enthusiast | Atención al Cliente</p>
-      <p class="max-w-3xl mx-auto">“Apasionado por la tecnología, con experiencia en atención al cliente y formación en sistemas informáticos. Mi objetivo: construir soluciones seguras y confiables en entornos globales.”</p>
+    <section id="home" class="flex items-center gap-8 py-24">
+      <img src="https://via.placeholder.com/150" alt="Miguel Reyes" class="w-32 h-32 rounded-full object-cover">
+      <div class="text-left">
+        <h1 class="text-4xl font-bold mb-4">Miguel Reyes</h1>
+        <p class="text-xl text-gray-400 mb-6">ASIR Student | Tech Enthusiast | Atención al Cliente</p>
+        <p class="max-w-lg mb-6">“Apasionado por la tecnología, con experiencia en atención al cliente y formación en sistemas informáticos. Mi objetivo: construir soluciones seguras y confiables en entornos globales.”</p>
+        <a href="#contacto" class="inline-block bg-teal-500 text-gray-900 px-6 py-2 rounded-full hover:bg-teal-400">Contáctame</a>
+      </div>
     </section>
 
     <section id="sobre-mi">
@@ -39,24 +43,24 @@
 
     <section id="formacion">
       <h2 class="text-3xl font-bold mb-4">Formación</h2>
-      <ol class="relative border-l border-gray-200">
+      <ol class="relative border-l border-gray-700">
         <li class="mb-10 ml-4">
-          <div class="absolute -left-1.5 mt-1.5 h-3 w-3 rounded-full bg-blue-500"></div>
-          <time class="mb-1 text-sm text-gray-500">En curso</time>
+          <div class="absolute -left-1.5 mt-1.5 h-3 w-3 rounded-full bg-gray-700"></div>
+          <time class="mb-1 text-sm text-gray-400">En curso</time>
           <h3 class="text-xl font-semibold">ASIR</h3>
         </li>
         <li class="mb-10 ml-4">
-          <div class="absolute -left-1.5 mt-1.5 h-3 w-3 rounded-full bg-blue-500"></div>
-          <time class="mb-1 text-sm text-gray-500">2 años</time>
+          <div class="absolute -left-1.5 mt-1.5 h-3 w-3 rounded-full bg-gray-700"></div>
+          <time class="mb-1 text-sm text-gray-400">2 años</time>
           <h3 class="text-xl font-semibold">Universidad Nacional de la Plata – Informática</h3>
         </li>
         <li class="mb-10 ml-4">
-          <div class="absolute -left-1.5 mt-1.5 h-3 w-3 rounded-full bg-blue-500"></div>
-          <time class="mb-1 text-sm text-gray-500">100h</time>
+          <div class="absolute -left-1.5 mt-1.5 h-3 w-3 rounded-full bg-gray-700"></div>
+          <time class="mb-1 text-sm text-gray-400">100h</time>
           <h3 class="text-xl font-semibold">Curso IoT – CEAC</h3>
         </li>
         <li class="ml-4">
-          <div class="absolute -left-1.5 mt-1.5 h-3 w-3 rounded-full bg-blue-500"></div>
+          <div class="absolute -left-1.5 mt-1.5 h-3 w-3 rounded-full bg-gray-700"></div>
           <h3 class="text-xl font-semibold">Oracle Database PL/SQL</h3>
         </li>
       </ol>
@@ -79,22 +83,22 @@
     <section id="competencias">
       <h2 class="text-3xl font-bold mb-4">Competencias</h2>
       <ul class="flex flex-wrap gap-4">
-        <li class="bg-blue-100 text-blue-800 px-4 py-2 rounded-full">💾 Bases de datos (Oracle PL/SQL, SQL)</li>
-        <li class="bg-blue-100 text-blue-800 px-4 py-2 rounded-full">⚙️ Sistemas Operativos (Linux, Windows)</li>
-        <li class="bg-blue-100 text-blue-800 px-4 py-2 rounded-full">🐍 Python (básico), HTML</li>
-        <li class="bg-blue-100 text-blue-800 px-4 py-2 rounded-full">🛠️ Hardware (reparación, mantenimiento)</li>
-        <li class="bg-blue-100 text-blue-800 px-4 py-2 rounded-full">🌍 Español / Inglés</li>
-        <li class="bg-blue-100 text-blue-800 px-4 py-2 rounded-full">🎧 Atención al Cliente, resolución de incidencias</li>
-        <li class="bg-blue-100 text-blue-800 px-4 py-2 rounded-full">🔒 Protocolos de calidad, ciberseguridad básica</li>
+        <li class="bg-gray-800 text-gray-200 border border-gray-700 px-4 py-2 rounded-full">💾 Bases de datos (Oracle PL/SQL, SQL)</li>
+        <li class="bg-gray-800 text-gray-200 border border-gray-700 px-4 py-2 rounded-full">⚙️ Sistemas Operativos (Linux, Windows)</li>
+        <li class="bg-gray-800 text-gray-200 border border-gray-700 px-4 py-2 rounded-full">🐍 Python (básico), HTML</li>
+        <li class="bg-gray-800 text-gray-200 border border-gray-700 px-4 py-2 rounded-full">🛠️ Hardware (reparación, mantenimiento)</li>
+        <li class="bg-gray-800 text-gray-200 border border-gray-700 px-4 py-2 rounded-full">🌍 Español / Inglés</li>
+        <li class="bg-gray-800 text-gray-200 border border-gray-700 px-4 py-2 rounded-full">🎧 Atención al Cliente, resolución de incidencias</li>
+        <li class="bg-gray-800 text-gray-200 border border-gray-700 px-4 py-2 rounded-full">🔒 Protocolos de calidad, ciberseguridad básica</li>
       </ul>
     </section>
 
     <section id="contacto">
       <h2 class="text-3xl font-bold mb-4">Contacto</h2>
-      <p>Email: <a href="mailto:tuemail@example.com" class="text-blue-600 hover:underline">tuemail@example.com</a></p>
-      <p>Teléfono: <a href="tel:+34123456789" class="text-blue-600 hover:underline">+34 123 456 789</a></p>
-      <p>LinkedIn: <a href="https://www.linkedin.com/in/tuusuario" class="text-blue-600 hover:underline" target="_blank">linkedin.com/in/tuusuario</a></p>
-      <p>GitHub: <a href="https://github.com/tuusuario" class="text-blue-600 hover:underline" target="_blank">github.com/tuusuario</a></p>
+      <p>Email: <a href="mailto:tuemail@example.com" class="text-teal-400 hover:text-teal-300 hover:underline">tuemail@example.com</a></p>
+      <p>Teléfono: <a href="tel:+34123456789" class="text-teal-400 hover:text-teal-300 hover:underline">+34 123 456 789</a></p>
+      <p>LinkedIn: <a href="https://www.linkedin.com/in/tuusuario" class="text-teal-400 hover:text-teal-300 hover:underline" target="_blank">linkedin.com/in/tuusuario</a></p>
+      <p>GitHub: <a href="https://github.com/tuusuario" class="text-teal-400 hover:text-teal-300 hover:underline" target="_blank">github.com/tuusuario</a></p>
     </section>
 
     <section id="proyectos">


### PR DESCRIPTION
## Summary
- switch layout and navigation to dark neutrals
- streamline hero with profile image and teal call-to-action
- unify timeline, badges, and contact links with gray tones and single accent color

## Testing
- `npm test` (fails: could not read package.json)
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68baba0705f883289db51c9770ece95f